### PR TITLE
fix/chore: initialize exit target/zone upon character load + typo correction

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -262,7 +262,7 @@ local function DestroyDeliveryTarget()
     end
 end
 
-local function DestoryInsideZones()
+local function DestroyInsideZones()
     DestroyPickupTarget()
     DestroyExitTarget()
     DestroyDutyTarget()
@@ -361,7 +361,7 @@ local function EnterLocation()
     isInsideDutyZone = false
     isInsideEntranceZone = false
 
-    DestoryInsideZones()
+    DestroyInsideZones()
     RegisterExitTarget()
     RegisterDutyTarget()
 end
@@ -380,7 +380,7 @@ local function ExitLocation()
     isInsideDutyZone = false
     isInsideEntranceZone = false
 
-    DestoryInsideZones()
+    DestroyInsideZones()
 
     if carryPackage then
         DropPackage()
@@ -437,6 +437,10 @@ local function DrawPackageLocationBlip()
 end
 
 -- Events
+
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+    RegisterExitTarget()
+end)
 
 RegisterNetEvent('qb-recyclejob:client:target:enterLocation', function()
     EnterLocation()


### PR DESCRIPTION
## Description

fixes being stuck inside of the recycle interior upon re-connection

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
 