### PR TITLE
Fix AddItem putting a string into the created date field

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,14 +8,14 @@ RegisterNetEvent('qb-recyclejob:server:getItem', function()
     for _ = 1, math.random(1, Config.MaxItemsReceived), 1 do
         local randItem = Config.ItemTable[math.random(1, #Config.ItemTable)]
         local amount = math.random(Config.MinItemReceivedQty, Config.MaxItemReceivedQty)
-        exports['qb-inventory']:AddItem(src, randItem, amount, false, false, 'qb-recyclejob:server:getItem')
+        exports['qb-inventory']:AddItem(src, randItem, amount, false, false, os.time())
         TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[randItem], 'add')
         Wait(500)
     end
 
     local chance = math.random(1, 100)
     if chance < 7 then
-        exports['qb-inventory']:AddItem(src, Config.ChanceItem, 1, false, false, 'qb-recyclejob:server:getItem')
+        exports['qb-inventory']:AddItem(src, Config.ChanceItem, 1, false, false, os.time())
         TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[Config.ChanceItem], 'add')
     end
 
@@ -23,7 +23,7 @@ RegisterNetEvent('qb-recyclejob:server:getItem', function()
     local odd = math.random(1, 10)
     if luck == odd then
         local random = math.random(1, 3)
-        exports['qb-inventory']:AddItem(src, Config.LuckyItem, random, false, false, 'qb-recyclejob:server:getItem')
+        exports['qb-inventory']:AddItem(src, Config.LuckyItem, random, false, false, os.time())
         TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[Config.LuckyItem], 'add')
     end
 end)


### PR DESCRIPTION
**Describe Pull request**
When recyclejob calls `AddItem`, it gives a string in the `created` field instead of a timestamp, causing inventory scripts to crash.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
