### PR TITLE
update qb-recycling 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lua",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/client/main.lua"
+        }
+    ]
+}

--- a/client/main.lua
+++ b/client/main.lua
@@ -146,7 +146,6 @@ end
 
 local function RegisterDutyTarget()
     local coords = vector3(Config.DutyLocation.x, Config.DutyLocation.y, Config.DutyLocation.z)
-
     if Config.UseTarget then
         dutyZone = exports['qb-target']:AddBoxZone(dutyTargetID, coords, 1, 1, {
             name = dutyTargetID,
@@ -526,6 +525,7 @@ local function sellMaterials()
                 menu[#menu+1] = {
                     header = QBCore.Shared.Items[k].label,
                     txt = 'Price: $'..v,
+                    icon = "nui://qb-inventory/html/images/" .. QBCore.Shared.Items[k].name .. ".png",
                     action = function()
                         local dialog = exports['qb-input']:ShowInput({
                             header = "Sell " .. QBCore.Shared.Items[k].label,
@@ -540,7 +540,7 @@ local function sellMaterials()
                             }
                         })
                         if not dialog and dialog.amount then return end
-                        TriggerServerEvent('qb-recyclejob:server:sellItem', k, dialog.amount)
+                        TriggerServerEvent('qb-recyclejob:server:sellItem', k, tonumber(dialog.amount))
                     end
                 }
             end
@@ -556,7 +556,7 @@ CreateThread(function()
             Wait(0)
         end
         local loc = Config.SellPed
-        local ped = CreatePed(4, GetHashKey('mp_m_freemode_01'), loc.x, loc.y, loc.z, 180.0, false, false)
+        local ped = CreatePed(4, GetHashKey('mp_m_freemode_01'), loc.x, loc.y, loc.z, loc.w, false, false)
         FreezeEntityPosition(ped, true)
         SetEntityInvincible(ped, true)
         SetBlockingOfNonTemporaryEvents(ped, true)
@@ -565,7 +565,7 @@ CreateThread(function()
                 options = {
                     {
                         icon = 'fas fa-dollar-sign',
-                        label = Lang:t('text.sell_materials'),
+                        label = 'Sell Materials',
                         action = function()
                             sellMaterials()
                         end

--- a/client/main.lua
+++ b/client/main.lua
@@ -191,7 +191,7 @@ local function sellMaterials()
     end)
 end
 
-local function CreateSales()
+local function Start()
     if Config.SellMaterials then 
         RequestModel(GetHashKey('s_m_m_dockwork_01'))
         while not HasModelLoaded(GetHashKey('s_m_m_dockwork_01')) do
@@ -234,10 +234,6 @@ local function CreateSales()
             end)
         end
     end
-end
-
-CreateThread(function()
-    CreateSales()
     for k, v in pairs (Config.PickupLocations) do
         RequestModel(Config.WarehouseObjects[v.model])
         while not HasModelLoaded(Config.WarehouseObjects[v.model]) do
@@ -494,4 +490,7 @@ CreateThread(function()
         Wait(100)
         end
     end
-end)
+end
+
+Wait(100)
+Start()

--- a/client/main.lua
+++ b/client/main.lua
@@ -2,301 +2,41 @@ local QBCore = exports['qb-core']:GetCoreObject()
 local carryPackage = nil
 local packageCoords = nil
 local onDuty = false
+local isBusy = false
+local inZone = {
+    ['pickupTarget'] = false,
+    ['enterLocation'] = false,
+    ['exitLocation'] = false,
+    ['dutyLocation'] = false,
+    ['targetCrate'] = false,
+    ['turnIn'] = false,
+    ['sellPed'] = false,
+}
+local props = {}
 
--- zone check
-
-local entranceTargetID = 'entranceTarget'
-local isInsideEntranceZone = false
-local entranceZone = nil
-
-local exitTargetID = 'exitTarget'
-local isInsideExitZone = false
-local exitZone = nil
-
-local deliveryTargetID = 'deliveryTarget'
-local isInsideDeliveryZone = false
-local deliveryZone = nil
-
-local dutyTargetID = 'dutyTarget'
-local isInsideDutyZone = false
-local dutyZone = nil
-
-local pickupTargetID = 'pickupTarget'
-local isInsidePickupZone = false
-local pickupZone = nil
-
--- Functions
-
-local function DestroyPickupTarget()
-    if not pickupZone then
-        return
-    end
-
-    if Config.UseTarget then
-        exports['qb-target']:RemoveZone(pickupTargetID)
-        pickupZone = nil
-    else
-        pickupZone:destroy()
-        pickupZone = nil
-        isInsidePickupZone = false
-    end
-end
-
-local function RegisterEntranceTarget()
-    local coords = vector3(Config.OutsideLocation.x, Config.OutsideLocation.y, Config.OutsideLocation.z)
-
-    if Config.UseTarget then
-        entranceZone = exports['qb-target']:AddBoxZone(entranceTargetID, coords, 1, 4, {
-            name = entranceTargetID,
-            heading = 44.0,
-            minZ = Config.OutsideLocation.z - 1.0,
-            maxZ = Config.OutsideLocation.z + 2.0,
-            debugPoly = false,
-        }, {
-            options = {
-                {
-                    type = 'client',
-                    event = 'qb-recyclejob:client:target:enterLocation',
-                    label = Lang:t('text.enter_warehouse'),
-                },
-            },
-            distance = 1.0
-        })
-    else
-        entranceZone = BoxZone:Create(coords, 1, 4, {
-            name = entranceTargetID,
-            heading = 44.0,
-            minZ = Config.OutsideLocation.z - 1.0,
-            maxZ = Config.OutsideLocation.z + 2.0,
-            debugPoly = false
-        })
-
-        entranceZone:onPlayerInOut(function(isPointInside)
-            if isPointInside then
-                exports['qb-core']:DrawText(Lang:t('text.point_enter_warehouse'), 'left')
-            else
-                exports['qb-core']:HideText()
-            end
-
-            isInsideEntranceZone = isPointInside
-        end)
-    end
-end
-
-local function RegisterExitTarget()
-    local coords = vector3(Config.InsideLocation.x, Config.InsideLocation.y, Config.InsideLocation.z)
-
-    if Config.UseTarget then
-        exitZone = exports['qb-target']:AddBoxZone(exitTargetID, coords, 1, 4, {
-            name = exitTargetID,
-            heading = 270,
-            minZ = Config.InsideLocation.z - 1.0,
-            maxZ = Config.InsideLocation.z + 2.0,
-            debugPoly = false,
-        }, {
-            options = {
-                {
-                    type = 'client',
-                    event = 'qb-recyclejob:client:target:exitLocation',
-                    label = Lang:t('text.exit_warehouse'),
-                },
-            },
-            distance = 1.0
-        })
-    else
-        exitZone = BoxZone:Create(coords, 1, 4, {
-            name = exitTargetID,
-            heading = 270,
-            minZ = Config.InsideLocation.z - 1.0,
-            maxZ = Config.InsideLocation.z + 2.0,
-            debugPoly = false
-        })
-
-        exitZone:onPlayerInOut(function(isPointInside)
-            if isPointInside then
-                exports['qb-core']:DrawText(Lang:t('text.point_exit_warehouse'), 'left')
-            else
-                exports['qb-core']:HideText()
-            end
-
-            isInsideExitZone = isPointInside
-        end)
-    end
-end
-
-local function DestroyExitTarget()
-    if not exitZone then
-        return
-    end
-
-    if Config.UseTarget then
-        exports['qb-target']:RemoveZone(exitTargetID)
-        exitZone = nil
-    else
-        exitZone:destroy()
-        exitZone = nil
-        isInsideExitZone = false
-    end
-end
-
-local function GetDutyTargetText()
-    local text = onDuty and Lang:t('text.clock_out') or Lang:t('text.clock_in')
-    return text
-end
-
-local function RegisterDutyTarget()
-    local coords = vector3(Config.DutyLocation.x, Config.DutyLocation.y, Config.DutyLocation.z)
-    if Config.UseTarget then
-        dutyZone = exports['qb-target']:AddBoxZone(dutyTargetID, coords, 1, 1, {
-            name = dutyTargetID,
-            heading = 270,
-            minZ = Config.DutyLocation.z - 2.0,
-            maxZ = Config.DutyLocation.z + 1.0,
-            debugPoly = false,
-        }, {
-            options = {
-                {
-                    type = 'client',
-                    event = 'qb-recyclejob:client:target:toggleDuty',
-                    label = GetDutyTargetText(),
-                },
-            },
-            distance = 1.0
-        })
-    else
-        dutyZone = BoxZone:Create(coords, 1, 1, {
-            name = dutyTargetID,
-            heading = 270,
-            minZ = Config.DutyLocation.z - 2.0,
-            maxZ = Config.DutyLocation.z + 1.0,
-            debugPoly = false
-        })
-
-        dutyZone:onPlayerInOut(function(isPointInside)
-            if isPointInside then
-                exports['qb-core']:DrawText(GetDutyTargetText(), 'left')
-            else
-                exports['qb-core']:HideText()
-            end
-
-            isInsideDutyZone = isPointInside
-        end)
-    end
-end
-
-local function DestroyDutyTarget()
-    if not dutyZone then
-        return
-    end
-
-    if Config.UseTarget then
-        exports['qb-target']:RemoveZone(dutyTargetID)
-        dutyZone = nil
-    else
-        dutyZone:destroy()
-        dutyZone = nil
-        isInsideDutyZone = false
-    end
-end
-
-local function RefreshDutyTarget()
-    DestroyDutyTarget()
-    RegisterDutyTarget()
-end
-
-
-local function RegisterDeliveyTarget()
-    local coords = vector3(Config.DropLocation.x, Config.DropLocation.y, Config.DropLocation.z)
-
-    if Config.UseTarget then
-        deliveryZone = exports['qb-target']:AddBoxZone(deliveryTargetID, coords, 1, 1, {
-            name = deliveryTargetID,
-            heading = 270,
-            minZ = Config.DropLocation.z - 2.0,
-            maxZ = Config.DropLocation.z + 1.0,
-            debugPoly = false,
-        }, {
-            options = {
-                {
-                    type = 'client',
-                    event = 'qb-recyclejob:client:target:dropPackage',
-                    label = Lang:t('text.hand_in_package'),
-                },
-            },
-            distance = 1.0
-        })
-    else
-        deliveryZone = BoxZone:Create(coords, 1, 1, {
-            name = deliveryTargetID,
-            heading = 270,
-            minZ = Config.DropLocation.z - 2.0,
-            maxZ = Config.DropLocation.z + 1.0,
-            debugPoly = false
-        })
-
-        deliveryZone:onPlayerInOut(function(isPointInside)
-            if isPointInside and carryPackage then
-                exports['qb-core']:DrawText(Lang:t('text.point_hand_in_package'), 'left')
-            else
-                exports['qb-core']:HideText()
-            end
-
-            isInsideDeliveryZone = isPointInside
-        end)
-    end
-end
-
-local function DestroyDeliveryTarget()
-    if not deliveryZone then
-        return
-    end
-
-    if Config.UseTarget then
-        exports['qb-target']:RemoveZone(deliveryTargetID)
-        deliveryZone = nil
-    else
-        deliveryZone:destroy()
-        deliveryZone = nil
-        isInsideDeliveryZone = false
-    end
-end
-
-local function DestroyInsideZones()
-    DestroyPickupTarget()
-    DestroyExitTarget()
-    DestroyDutyTarget()
-    DestroyDeliveryTarget()
-end
-
-local function loadAnimDict(dict)
-    while (not HasAnimDictLoaded(dict)) do
-        RequestAnimDict(dict)
-        Wait(5)
-    end
-end
-
-local function ScrapAnim()
-    local time = 5
-    loadAnimDict('mp_car_bomb')
-    TaskPlayAnim(PlayerPedId(), 'mp_car_bomb', 'car_bomb_mechanic', 3.0, 3.0, -1, 16, 0, false, false, false)
-    local openingDoor = true
-
-    CreateThread(function()
-        while openingDoor do
-            TaskPlayAnim(PlayerPedId(), 'mp_car_bomb', 'car_bomb_mechanic', 3.0, 3.0, -1, 16, 0, 0, 0, 0)
-            Wait(1000)
-            time = time - 1
-            if time <= 0 then
-                openingDoor = false
-                StopAnimTask(PlayerPedId(), 'mp_car_bomb', 'car_bomb_mechanic', 1.0)
-            end
+AddEventHandler('onResourceStop', function(resourceName)
+    if resourceName == GetCurrentResourceName() then
+        for k, v in pairs (props) do
+            DeleteObject(v)
         end
-    end)
+        if carryPackage then
+            DeleteObject(carryPackage)
+        end
+        if packageCoords then
+            SetEntityDrawOutline(props[packageCoords], false)
+        end
+    end
+end)
+
+local function DrawPackageLocationBlip()
+    if not Config.DrawPackageLocationBlip then return end
+    SetEntityDrawOutline(props[packageCoords], true)
+    SetEntityDrawOutlineColor(props[packageCoords], 15,20,60)
 end
 
 local function GetRandomPackage()
-    packageCoords = Config.PickupLocations[math.random(1, #Config.PickupLocations)]
-    RegisterPickupTarget(packageCoords)
+    packageCoords = math.random(1, #Config.PickupLocations)
+    DrawPackageLocationBlip()
 end
 
 local function PickupPackage()
@@ -314,6 +54,7 @@ local function PickupPackage()
     AttachEntityToEntity(object, PlayerPedId(), GetPedBoneIndex(PlayerPedId(), 57005), 0.05, 0.1, -0.3, 300.0, 250.0, 20.0, true, true, false, true, 1, true)
     carryPackage = object
 end
+
 
 local function DropPackage()
     ClearPedTasks(PlayerPedId())
@@ -333,18 +74,7 @@ local function SetLocationBlip()
     EndTextCommandSetBlipName(RecycleBlip)
 end
 
-local function buildInteriorDesign()
-    for _, pickuploc in pairs(Config.PickupLocations) do
-        local model = GetHashKey(Config.WarehouseObjects[math.random(1, #Config.WarehouseObjects)])
-        RequestModel(model)
-        while not HasModelLoaded(model) do
-            Wait(0)
-        end
-        local obj = CreateObject(model, pickuploc.x, pickuploc.y, pickuploc.z, false, true, true)
-        PlaceObjectOnGroundProperly(obj)
-        FreezeEntityPosition(obj, true)
-    end
-end
+SetLocationBlip()
 
 local function EnterLocation()
     DoScreenFadeOut(500)
@@ -352,17 +82,7 @@ local function EnterLocation()
         Wait(10)
     end
     SetEntityCoords(PlayerPedId(), Config.InsideLocation.x, Config.InsideLocation.y, Config.InsideLocation.z)
-    buildInteriorDesign()
     DoScreenFadeIn(500)
-
-    isInsidePickupZone = false
-    isInsideExitZone = false
-    isInsideDutyZone = false
-    isInsideEntranceZone = false
-
-    DestroyInsideZones()
-    RegisterExitTarget()
-    RegisterDutyTarget()
 end
 
 local function ExitLocation()
@@ -374,166 +94,84 @@ local function ExitLocation()
     DoScreenFadeIn(500)
 
     onDuty = false
-    isInsidePickupZone = false
-    isInsideExitZone = false
-    isInsideDutyZone = false
-    isInsideEntranceZone = false
-
-    DestroyInsideZones()
 
     if carryPackage then
         DropPackage()
     end
 end
 
-function RegisterPickupTarget(coords)
-    local targetCoords = vector3(coords.x, coords.y, coords.z)
-
-    if Config.UseTarget then
-        pickupZone = exports['qb-target']:AddBoxZone(pickupTargetID, targetCoords, 4, 1.5, {
-            name = pickupTargetID,
-            heading = coords.h,
-            minZ = coords.z - 1.0,
-            maxZ = coords.z + 2.0,
-            debugPoly = false,
-        }, {
-            options = {
-                {
-                    type = 'client',
-                    event = 'qb-recyclejob:client:target:pickupPackage',
-                    label = Lang:t('text.get_package'),
-                },
-            },
-            distance = 1.0
-        })
-    else
-        pickupZone = BoxZone:Create(targetCoords, 4, 1.5, {
-            name = pickupTargetID,
-            heading = coords.h,
-            minZ = coords.z - 1.0,
-            maxZ = coords.z + 2.0,
-            debugPoly = false
-        })
-
-        pickupZone:onPlayerInOut(function(isPointInside)
-            if isPointInside then
-                exports['qb-core']:DrawText(Lang:t('text.point_get_package'), 'left')
-            else
-                exports['qb-core']:HideText()
-            end
-
-            isInsidePickupZone = isPointInside
-        end)
-    end
-end
-
-local function DrawPackageLocationBlip()
-    if not Config.DrawPackageLocationBlip then
-        return
-    end
-
-    DrawMarker(2, packageCoords.x, packageCoords.y, packageCoords.z + 3, 0, 0, 0, 180.0, 0, 0, 0.5, 0.5, 0.5, 255, 255, 0, 100, false, false, 2, true, nil, nil, false)
-end
-
--- Events
-
-RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
-    RegisterExitTarget()
-end)
-
-RegisterNetEvent('qb-recyclejob:client:target:enterLocation', function()
-    EnterLocation()
-end)
-
-RegisterNetEvent('qb-recyclejob:client:target:exitLocation', function()
-    ExitLocation()
-end)
-
-RegisterNetEvent('qb-recyclejob:client:target:toggleDuty', function()
-    onDuty = not onDuty
+local function toggleDuty()
     if onDuty then
-        QBCore.Functions.Notify(Lang:t('success.you_have_been_clocked_in'), 'success')
-        GetRandomPackage()
+        QBCore.Functions.Notify(Lang:t('text.clock_out'), 'success')
+        onDuty = false
+        if packageCoords then
+            SetEntityDrawOutline(props[packageCoords], false)
+            packageCoords = nil
+        end
     else
-        QBCore.Functions.Notify(Lang:t('error.you_have_clocked_out'), 'error')
-        DestroyPickupTarget()
+        QBCore.Functions.Notify(Lang:t('text.clock_in'), 'success')
+        onDuty = true
+        GetRandomPackage()
     end
+end
 
-    if carryPackage then
-        DropPackage()
-    end
-
-    RefreshDutyTarget()
-    DestroyDeliveryTarget()
-end)
-
-RegisterNetEvent('qb-recyclejob:client:target:pickupPackage', function()
-    if not pickupZone or carryPackage then
-        return
-    end
-
-    if not Config.UseTarget and not isInsidePickupZone then
-        return
-    end
-
+local function pickUp()
+    isBusy = true
     QBCore.Functions.Progressbar('pickup_reycle_package', Lang:t('text.picking_up_the_package'), Config.PickupActionDuration, false, true, {
         disableMovement = true,
         disableCarMovement = true,
         disableMouse = false,
         disableCombat = true
-    }, {}, {}, {}, function()
+    }, {
+        animDict = 'mp_car_bomb',
+        anim = 'car_bomb_mechanic',
+        flags = 16
+    }, {}, {}, function()
+        isBusy = false
+        SetEntityDrawOutline(props[packageCoords], false)
         packageCoords = nil
-        ClearPedTasks(PlayerPedId())
         PickupPackage()
-        DestroyPickupTarget()
-        RegisterDeliveyTarget()
+    end, function()
+        isBusy = false
     end)
-end)
 
-RegisterNetEvent('qb-recyclejob:client:target:dropPackage', function()
-    if not carryPackage or not deliveryZone then
-        return
-    end
+end
 
-    if not Config.UseTarget and not isInsideDeliveryZone then
-        return
-    end
-
+local function handInPackage()
     DropPackage()
-    ScrapAnim()
-    DestroyDeliveryTarget()
     QBCore.Functions.Progressbar('deliver_reycle_package', Lang:t('text.unpacking_the_package'), Config.DeliveryActionDuration, false, true, {
         disableMovement = true,
         disableCarMovement = true,
         disableMouse = false,
         disableCombat = true
-    }, {}, {}, {}, function()
-        -- Done
-        StopAnimTask(PlayerPedId(), 'mp_car_bomb', 'car_bomb_mechanic', 1.0)
+    }, {
+        animDict = 'mp_car_bomb',
+        anim = 'car_bomb_mechanic',
+        flags = 16
+    }, {}, {}, function()
         TriggerServerEvent('qb-recyclejob:server:getItem')
         GetRandomPackage()
     end)
-end)
+end
 
--- Threads
 local function sellMaterials()
     QBCore.Functions.TriggerCallback('qb-recyclejob:server:getPriceList', function(data)
         local menu = {}
-        if data == false then QBCore.Functions.Notify('You Are To Far To Sell Things', 'error') return end
+        if data == false then QBCore.Functions.Notify(Lang:t('error.too_far_to_sell') 'error') return end
         for k, v in pairs (data) do
             if QBCore.Functions.HasItem(k) then
                 menu[#menu+1] = {
                     header = QBCore.Shared.Items[k].label,
-                    txt = 'Price: $'..v,
+                    txt = Lang:t('text.price', {price = v}),
                     icon = "nui://qb-inventory/html/images/" .. QBCore.Shared.Items[k].name .. ".png",
                     action = function()
                         local dialog = exports['qb-input']:ShowInput({
-                            header = "Sell " .. QBCore.Shared.Items[k].label,
-                            submitText = "Sell",
+                            header = Lang:t('text.sell') .. ' ' ..  QBCore.Shared.Items[k].label,
+                            submitText = Lang:t('text.sell') ,
                             inputs = {
                                 {
-                                    text = "Amount",
-                                    header = "Amount",
+                                    text = Lang:t('text.amount'),
+                                    header = Lang:t('text.amount'),
                                     type = "number",
                                     name = "amount",
                                 },
@@ -545,18 +183,22 @@ local function sellMaterials()
                 }
             end
         end
+        if #menu == 0 then
+            QBCore.Functions.Notify(Lang:t('error.nothing_to_sell'), 'error')
+            return
+        end
         exports['qb-menu']:openMenu(menu)
     end)
 end
 
-CreateThread(function()
+local function CreateSales()
     if Config.SellMaterials then 
-        RequestModel(GetHashKey('mp_m_freemode_01'))
-        while not HasModelLoaded(GetHashKey('mp_m_freemode_01')) do
+        RequestModel(GetHashKey('s_m_m_dockwork_01'))
+        while not HasModelLoaded(GetHashKey('s_m_m_dockwork_01')) do
             Wait(0)
         end
         local loc = Config.SellPed
-        local ped = CreatePed(4, GetHashKey('mp_m_freemode_01'), loc.x, loc.y, loc.z, loc.w, false, false)
+        local ped = CreatePed(4, GetHashKey('s_m_m_dockwork_01'), loc.x, loc.y, loc.z, loc.w, false, false)
         FreezeEntityPosition(ped, true)
         SetEntityInvincible(ped, true)
         SetBlockingOfNonTemporaryEvents(ped, true)
@@ -565,7 +207,7 @@ CreateThread(function()
                 options = {
                     {
                         icon = 'fas fa-dollar-sign',
-                        label = 'Sell Materials',
+                        label = Lang:t('text.sell_materials'),
                         action = function()
                             sellMaterials()
                         end
@@ -574,117 +216,282 @@ CreateThread(function()
                 distance = 1.5
             })
         else
-            sellZone = BoxZone:Create(loc, 4, 1.5, {
-                name = pickupTargetID,
+           local sellZone = BoxZone:Create(vector3(loc.x, loc.y, loc.z), 2.0, 1.5, {
+                name = 'sellPed',
                 heading = 180.0,
                 minZ = loc.z - 1.0,
                 maxZ = loc.z + 2.0,
                 debugPoly = false
             })
             sellZone:onPlayerInOut(function(isPointInside)
-                local brake = false
                 if isPointInside then
-                    exports['qb-core']:DrawText(Lang:t('text.point_get_package'), 'left')
-                    repeat
-                        Wait(0)
-                        if IsControlJustReleased(0, 38) then
-                            brake = true
-                            exports['qb-core']:KeyPressed()
-                            sellMaterials()
-                        end
-                    until brake
+                    inZone['sellPed'] = true
+                    exports['qb-core']:DrawText(Lang:t('text.point_sell_materials'), 'left')
                 else
+                    inZone['sellPed'] = false
                     exports['qb-core']:HideText()
                 end
             end)
         end
     end
-    local sleep = 500
+end
 
-    while not LocalPlayer.state.isLoggedIn do
-        -- do nothing
-        Wait(sleep)
+CreateThread(function()
+    CreateSales()
+    for k, v in pairs (Config.PickupLocations) do
+        RequestModel(Config.WarehouseObjects[v.model])
+        while not HasModelLoaded(Config.WarehouseObjects[v.model]) do
+            Wait(0)
+        end
+        props[k] = CreateObject(Config.WarehouseObjects[v.model], v.loc.x, v.loc.y, v.loc.z, false, true, true)
+        PlaceObjectOnGroundProperly(props[k])
+        FreezeEntityPosition(props[k], true)
+        if Config.UseTarget then 
+            exports['qb-target']:AddTargetEntity(props[k], {
+                options = {
+                    {
+                        type = 'client',
+                        label = Lang:t('text.get_package'),
+                        icon = 'fas fa-box',
+                        action = function()
+                            if not isBusy then 
+                                pickUp()
+                            end
+                        end,
+                        canInteract = function()
+                            if packageCoords == k then 
+                                if isBusy == false then 
+                                    return true
+                                end
+                            end
+                        end,
+                    },
+                },
+                distance = 1.5
+            })
+        else
+            local zones = {}
+            zones[k] = BoxZone:Create(v.loc, 4, 2.0, {
+                name = zones[k],
+                heading = v.loc.w + 20,
+                minZ = v.loc.z - 1.0,
+                maxZ = v.loc.z + 2.0,
+                debugPoly = false
+            })
+            zones[k]:onPlayerInOut(function(isPointInside)
+                if isPointInside then
+                    if k == packageCoords then
+                       inZone['targetCrate'] = true
+                        exports['qb-core']:DrawText(Lang:t('text.point_get_package'), 'left')
+                    end
+                else
+                    inZone['targetCrate'] = false
+                    exports['qb-core']:HideText()
+                end
+            end)
+        end
     end
-
-    SetLocationBlip()
-    RegisterEntranceTarget()
-
     if Config.UseTarget then
-        if not Config.DrawPackageLocationBlip then
-            return
-        end
-
-        while true do
-            sleep = 500
-
-            if onDuty and packageCoords and not carryPackage then
-                sleep = 0
-                DrawPackageLocationBlip()
-            end
-
-            Wait(sleep)
-        end
+        exports['qb-target']:AddBoxZone('enterLocation', vector3(Config.OutsideLocation.x, Config.OutsideLocation.y, Config.OutsideLocation.z), 4, 1.5, {
+            name = 'enterLocation',
+            heading = 44.0,
+            minZ = Config.OutsideLocation.z - 1.0,
+            maxZ = Config.OutsideLocation.z + 2.0,
+            debugPoly = false,
+        }, {
+            options = {
+                {
+                    type = 'client',
+                    label = Lang:t('text.enter_warehouse'),
+                    action = function()
+                        EnterLocation()
+                    end,
+                },
+            },
+            distance = 1.0
+        })
+        exports['qb-target']:AddBoxZone('exitLocation', vector3(Config.InsideLocation.x, Config.InsideLocation.y, Config.InsideLocation.z), 4, 1.5, {
+            name = 'exitLocation',
+            heading = 44.0,
+            minZ = Config.InsideLocation.z - 1.0,
+            maxZ = Config.InsideLocation.z + 2.0,
+            debugPoly = false,
+        }, {
+            options = {
+                {
+                    type = 'client',
+                    label = Lang:t('text.exit_warehouse'),
+                    action = function()
+                        ExitLocation()
+                    end,
+                },
+            },
+            distance = 1.0
+        })
+        exports['qb-target']:AddBoxZone('dutyLocation', vector3(Config.DutyLocation.x, Config.DutyLocation.y, Config.DutyLocation.z), 4, 1.5, {
+            name = 'dutyLocation',
+            heading = 44.0,
+            minZ = Config.DutyLocation.z - 1.0,
+            maxZ = Config.DutyLocation.z + 2.0,
+            debugPoly = false,
+        }, {
+            options = {
+                {
+                    type = 'client',
+                    label = Lang:t('text.toggle_duty'),
+                    action = function()
+                        toggleDuty()
+                    end,
+                },
+            },
+            distance = 1.0
+        })
+        exports['qb-target']:AddBoxZone('recycleDrop', vector3(Config.DropLocation.x, Config.DropLocation.y, Config.DropLocation.z), 4, 1.5, {
+            name = 'recycleDrop',
+            heading = 44.0,
+            minZ = Config.DropLocation.z - 1.0,
+            maxZ = Config.DropLocation.z + 2.0,
+            debugPoly = false,
+        }, {
+            options = {
+                {
+                    type = 'client',
+                    label = Lang:t('text.hand_in_package'),
+                    action = function()
+                        handInPackage()
+                    end,
+                    canInteract = function()
+                        if carryPackage then
+                            return true
+                        end
+                    end,
+                },
+            },
+            distance = 1.5
+        })
     else
+        local enterZone = BoxZone:Create(vector3(Config.OutsideLocation.x, Config.OutsideLocation.y, Config.OutsideLocation.z), 4, 1.5, {
+            name = 'enterLocation',
+            heading = 133.0,
+            minZ = Config.OutsideLocation.z - 1.0,
+            maxZ = Config.OutsideLocation.z + 2.0,
+            debugPoly = false
+        })
+        local exitZone = BoxZone:Create(vector3(Config.InsideLocation.x, Config.InsideLocation.y, Config.InsideLocation.z), 4, 1.5, {
+            name = 'exitLocation',
+            heading = 180.0,
+            minZ = Config.InsideLocation.z - 1.0,
+            maxZ = Config.InsideLocation.z + 2.0,
+            debugPoly = false
+        })
+        local dutyZone = BoxZone:Create(vector3(Config.DutyLocation.x, Config.DutyLocation.y, Config.DutyLocation.z-1), 2.0, 1.5, {
+            name = 'dutyLocation',
+            heading = 180.0,
+            minZ = Config.DutyLocation.z - 2.0,
+            maxZ = Config.DutyLocation.z + 1.0,
+            debugPoly = false
+        })
+        local turnIn = BoxZone:Create(vector3(Config.DropLocation.x, Config.DropLocation.y, Config.DropLocation.z), 2.0, 1.5, {
+            name = 'recycleDrop',
+            heading = 180.0,
+            minZ = Config.DropLocation.z - 1.0,
+            maxZ = Config.DropLocation.z + 2.0,
+            debugPoly = false
+        })
+        enterZone:onPlayerInOut(function(isPointInside)
+            if isPointInside then
+                exports['qb-core']:DrawText(Lang:t('text.point_enter_warehouse'), 'left')
+                inZone['enterLocation'] = isPointInside
+            else
+                exports['qb-core']:HideText()
+                inZone['enterLocation'] = isPointInside
+            end
+        end)
+        exitZone:onPlayerInOut(function(isPointInside)
+            if isPointInside then
+                exports['qb-core']:DrawText(Lang:t('text.point_exit_warehouse'), 'left')
+                inZone['exitLocation'] = isPointInside
+            else
+                exports['qb-core']:HideText()
+                inZone['exitLocation'] = isPointInside
+            end
+        end)
+        dutyZone:onPlayerInOut(function(isPointInside)
+            if isPointInside then
+                exports['qb-core']:DrawText(Lang:t('text.point_toggle_duty'), 'left')
+                inZone['dutyLocation'] = isPointInside
+            else
+                exports['qb-core']:HideText()
+                inZone['dutyLocation'] = isPointInside
+            end
+        end)
+        turnIn:onPlayerInOut(function(isPointInside)
+            if isPointInside then
+                if carryPackage then
+                    inZone['turnIn'] = isPointInside
+                    exports['qb-core']:DrawText(Lang:t('text.point_hand_in_package'), 'left')
+                end
+            else
+                exports['qb-core']:HideText()
+                inZone['turnIn'] = isPointInside
+            end
+        end)
+
         while true do
-            sleep = 500
-
-            if isInsideEntranceZone then
-                sleep = 0
-                if IsControlJustReleased(0, 38) then
-                    exports['qb-core']:KeyPressed()
-                    Wait(500)
-                    TriggerEvent('qb-recyclejob:client:target:enterLocation')
-                    exports['qb-core']:HideText()
+            if inZone['enterLocation'] then
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['enterLocation']
+                if inZone['enterLocation'] then
+                    EnterLocation()
                 end
             end
-
-            if isInsideExitZone then
-                sleep = 0
-                if IsControlJustReleased(0, 38) then
-                    exports['qb-core']:KeyPressed()
-                    Wait(500)
-                    TriggerEvent('qb-recyclejob:client:target:exitLocation')
-                    exports['qb-core']:HideText()
+            if inZone['exitLocation'] then
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['exitLocation']
+                if inZone['exitLocation'] then
+                    ExitLocation()
                 end
             end
-
-            if isInsideDutyZone then
-                sleep = 0
-                if IsControlJustReleased(0, 38) then
-                    exports['qb-core']:KeyPressed()
-                    Wait(500)
-                    TriggerEvent('qb-recyclejob:client:target:toggleDuty')
-                    exports['qb-core']:HideText()
+            if inZone['dutyLocation'] then
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['dutyLocation']
+                if inZone['dutyLocation'] then
+                    toggleDuty()
                 end
             end
-
-            if onDuty then
-                if isInsidePickupZone and not carryPackage then
-                    sleep = 0
-                    if IsControlJustReleased(0, 38) then
-                        exports['qb-core']:KeyPressed()
-                        Wait(500)
-                        TriggerEvent('qb-recyclejob:client:target:pickupPackage')
-                        exports['qb-core']:HideText()
-                    end
-                elseif packageCoords and not carryPackage then
-                    sleep = 0
-                    DrawPackageLocationBlip()
-                end
-
-                if isInsideDeliveryZone and carryPackage then
-                    sleep = 0
-                    if IsControlJustReleased(0, 38) then
-                        exports['qb-core']:KeyPressed()
-                        Wait(500)
-                        TriggerEvent('qb-recyclejob:client:target:dropPackage')
-                        exports['qb-core']:HideText()
+            if inZone['targetCrate'] then
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['targetCrate']
+                exports['qb-core']:HideText()
+                if inZone['targetCrate'] then
+                    if not isBusy then 
+                        pickUp()
                     end
                 end
             end
-
-            Wait(sleep)
+            if inZone['turnIn'] then
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['turnIn'] or not carryPackage
+                if inZone['turnIn'] then
+                    if carryPackage then
+                        handInPackage()
+                    end
+                end
+            end
+            if inZone['sellPed'] then 
+                repeat
+                    Wait(1)
+                until IsControlJustReleased(0, 38) or not inZone['sellPed']
+                if inZone['sellPed'] then
+                    sellMaterials()
+                end
+            end
+        Wait(100)
         end
     end
-
 end)

--- a/config.lua
+++ b/config.lua
@@ -9,7 +9,7 @@ Config = {
 	DropLocation            = vector4(1048.224, -3097.071, -38.999, 274.810),
 	SellMaterials = true, --  allow players to sell materials to a ped 
 	LimitedMaterials = true, -- limit the amount of materials that can be sold
-	SellPed = vector3(1048.224, -3097.071, -38.999),
+	SellPed = vector4(1049.84, -3094.08, -40.0, 178.84),
 	DrawPackageLocationBlip = true,
 
 	PickupActionDuration    = math.random(4000, 6000),

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = {
 	-- **** IMPORTANT ****
 	-- UseTarget should only be set to true when using qb-target
-	UseTarget               = false,
+	UseTarget               = GetConvar('UseTarget', 'false') == 'true',
 
 	OutsideLocation         = vector4(55.55, 6472.18, 31.43, 44.0),
 	InsideLocation          = vector4(1073.0, -3102.49, -39.0, 266.61),

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = {
 	-- **** IMPORTANT ****
 	-- UseTarget should only be set to true when using qb-target
-	UseTarget               = GetConvar('UseTarget', 'false') == 'true',
+	UseTarget               = false,
 
 	OutsideLocation         = vector4(55.55, 6472.18, 31.43, 44.0),
 	InsideLocation          = vector4(1073.0, -3102.49, -39.0, 266.61),
@@ -9,36 +9,34 @@ Config = {
 	DropLocation            = vector4(1048.224, -3097.071, -38.999, 274.810),
 	SellMaterials = true, --  allow players to sell materials to a ped 
 	LimitedMaterials = true, -- limit the amount of materials that can be sold
-	SellPed = vector4(1049.84, -3094.08, -40.0, 178.84),
+	SellPed 				= vector4(1049.84, -3094.08, -40.0, 178.84),
 	DrawPackageLocationBlip = true,
 
 	PickupActionDuration    = math.random(4000, 6000),
 	DeliveryActionDuration  = 5000,
 
 	PickupLocations         = {
-		[1]  = vector4(1067.68, -3095.57, -39.9, 342.39),
-		[2]  = vector4(1065.20, -3095.57, -39.9, 342.39),
-		[3]  = vector4(1062.73, -3095.57, -39.9, 342.39),
-		[4]  = vector4(1060.37, -3095.57, -39.9, 342.39),
-		[5]  = vector4(1057.95, -3095.57, -39.9, 342.39),
-		[6]  = vector4(1055.58, -3095.57, -39.9, 342.39),
-		[7]  = vector4(1053.09, -3095.57, -39.9, 342.39),
-
-		[8]  = vector4(1053.07, -3102.62, -39.9, 342.39),
-		[9]  = vector4(1055.49, -3102.62, -39.9, 342.39),
-		[10] = vector4(1057.93, -3102.62, -39.9, 342.39),
-		[11] = vector4(1060.19, -3102.62, -39.9, 342.39),
-		[12] = vector4(1062.71, -3102.62, -39.9, 342.39),
-		[13] = vector4(1065.19, -3102.62, -39.9, 342.39),
-		[14] = vector4(1067.46, -3102.62, -39.9, 342.39),
-
-		[15] = vector4(1067.69, -3109.71, -39.9, 342.39),
-		[16] = vector4(1065.13, -3109.71, -39.9, 342.39),
-		[17] = vector4(1062.70, -3109.71, -39.9, 342.39),
-		[18] = vector4(1060.24, -3109.71, -39.9, 342.39),
-		[19] = vector4(1057.76, -3109.71, -39.9, 342.39),
-		[20] = vector4(1055.52, -3109.71, -39.9, 342.39),
-		[21] = vector4(1053.16, -3109.71, -39.9, 342.39),
+		{model = math.random(1,7), loc = vector4(1067.68, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1065.20, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1062.73, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1060.37, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1057.95, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1055.58, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1053.09, -3095.57, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1053.07, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1055.49, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1057.93, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1060.19, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1062.71, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1065.19, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1067.46, -3102.62, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1067.69, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1065.13, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1062.70, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1060.24, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1057.76, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1055.52, -3109.71, -39.9, 342.39),},
+		{model = math.random(1,7), loc = vector4(1053.16, -3109.71, -39.9, 342.39),},
 	},
 	WarehouseObjects        = {
 		[1] = 'prop_boxpile_05a',

--- a/config.lua
+++ b/config.lua
@@ -7,7 +7,9 @@ Config = {
 	InsideLocation          = vector4(1073.0, -3102.49, -39.0, 266.61),
 	DutyLocation            = vector4(1048.7, -3100.62, -38.2, 88.02),
 	DropLocation            = vector4(1048.224, -3097.071, -38.999, 274.810),
-
+	SellMaterials = true, --  allow players to sell materials to a ped 
+	LimitedMaterials = true, -- limit the amount of materials that can be sold
+	SellPed = vector3(1048.224, -3097.071, -38.999),
 	DrawPackageLocationBlip = true,
 
 	PickupActionDuration    = math.random(4000, 6000),

--- a/config.lua
+++ b/config.lua
@@ -13,12 +13,6 @@ Config = {
 	PickupActionDuration    = math.random(4000, 6000),
 	DeliveryActionDuration  = 5000,
 
-	MaxItemsReceived        = 5,
-	MinItemReceivedQty      = 2,
-	MaxItemReceivedQty      = 6,
-	ChanceItem              = 'cryptostick',
-	LuckyItem               = 'rubber',
-
 	PickupLocations         = {
 		[1]  = vector4(1067.68, -3095.57, -39.9, 342.39),
 		[2]  = vector4(1065.20, -3095.57, -39.9, 342.39),
@@ -54,13 +48,4 @@ Config = {
 		[7] = 'prop_boxpile_08a',
 	},
 	PickupBoxModel          = 'prop_cs_cardbox_01',
-	ItemTable               = {
-		[1] = 'metalscrap',
-		[2] = 'plastic',
-		[3] = 'copper',
-		[4] = 'iron',
-		[5] = 'aluminum',
-		[6] = 'steel',
-		[7] = 'glass',
-	}
 }

--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -1,30 +1,38 @@
 local Translations = {
     success = {
-        you_have_been_clocked_in = "لقد تم تسجيل دخولك",
+        you_have_been_clocked_in = "تم تسجيل دخولك",
+        sold = 'لقد بعت %{amount} %{item} مقابل $%{price}',
     },
     text = {
-        point_enter_warehouse = "[E] أدخل المستودع",
-        enter_warehouse= "أدخل المستودع",
-        exit_warehouse= "خروج من المستودع",
-        point_exit_warehouse = "[E] مستودع الخروج",
-        clock_out = "[E] تسجيل خروج",
-        clock_in = "[E] تسجيل دخول",
-        hand_in_package = "تسليم حزمة",
-        point_hand_in_package = "[E] تسليم حزمة",
-        get_package = "احصل على الحزمة",
-        point_get_package = "[E] احصل على الحزمة",
-        picking_up_the_package = "استلام الطرد",
-        unpacking_the_package = "تفريغ حزمة",
+        point_enter_warehouse = "[E] دخول المستودع",
+        enter_warehouse= "دخول المستودع",
+        exit_warehouse= "مغادرة المستودع",
+        point_exit_warehouse = "[E] مغادرة المستودع",
+        toggle_duty = "تغيير الحالة",
+        point_toggle_duty = "[E] تغيير الحالة",
+        hand_in_package = "تسليم الطرد",
+        point_hand_in_package = "[E] تسليم الطرد",
+        get_package = "احصل على الطرد",
+        point_get_package = "[E] احصل على الطرد",
+        picking_up_the_package = "جاري التقاط الطرد",
+        unpacking_the_package = "جاري فتح الطرد",
+        clock_in = "تم تسجيل دخولك",
+        clock_out = "تم تسجيل خروجك",
+        sell_materials = "بيع المواد",
+        point_sell_materials = "[E] بيع المواد",
+        price = "السعر: $%{price}",
+        amount = "الكمية",
+        sell = "بيع",
     },
     error = {
-        you_have_clocked_out = "لقد تم تسجيل خروج"
+        you_have_clocked_out = "تم تسجيل خروجك",
+        nothing_to_sell = "ليس لديك شيء لتبيعه",
+        out_of_stock = "%{item} غير متوفر",
+        too_far_to_sell = "أنت بعيد جدًا لبيع المواد",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'ar' then
-    Lang = Locale:new({
-        phrases = Translations,
-        warnOnMissing = true,
-        fallbackLang = Lang,
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/ar.lua
+++ b/locales/ar.lua
@@ -32,7 +32,10 @@ local Translations = {
     },
 }
 
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'ar' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -1,30 +1,38 @@
 local Translations = {
     success = {
         you_have_been_clocked_in = "Du er logget ind",
+        sold = 'Du har solgt %{amount} %{item} for $%{price}',
     },
     text = {
         point_enter_warehouse = "[E] Gå ind i lageret",
-        enter_warehouse= "Gå ind i lageret",
-        exit_warehouse= "Gå ud af lageret",
+        enter_warehouse = "Gå ind i lageret",
+        exit_warehouse = "Gå ud af lageret",
         point_exit_warehouse = "[E] Gå ud af lageret",
-        clock_out = "[E] Log ind",
-        clock_in = "[E] Log ud",
-        hand_in_package = "Indlever pakke",
-        point_hand_in_package = "[E] Indlever pakke",
-        get_package = "Modtag pakke",
-        point_get_package = "[E] Modtage pakke",
-        picking_up_the_package = "Afhentning af pakken",
-        unpacking_the_package = "Udpakning af pakken",
+        toggle_duty = "Skift vagtstatus",
+        point_toggle_duty = "[E] Skift vagtstatus",
+        hand_in_package = "Aflever pakke",
+        point_hand_in_package = "[E] Aflever pakke",
+        get_package = "Hent pakke",
+        point_get_package = "[E] Hent pakke",
+        picking_up_the_package = "Henter pakken",
+        unpacking_the_package = "Pakker pakken ud",
+        clock_in = "Du er logget ind",
+        clock_out = "Du er logget ud",
+        sell_materials = "Sælg materialer",
+        point_sell_materials = "[E] Sælg materialer",
+        price = "Pris: $%{price}",
+        amount = "Mængde",
+        sell = "Sælg",
     },
     error = {
-        you_have_clocked_out = "Du er logget ud"
+        you_have_clocked_out = "Du er logget ud",
+        nothing_to_sell = "Du har intet at sælge",
+        out_of_stock = "%{item} er udsolgt",
+        too_far_to_sell = "Du er for langt væk til at sælge",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'da' then
-    Lang = Locale:new({
-        phrases = Translations,
-        warnOnMissing = true,
-        fallbackLang = Lang,
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/da.lua
+++ b/locales/da.lua
@@ -32,7 +32,10 @@ local Translations = {
     },
 }
 
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'da' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -1,30 +1,38 @@
 local Translations = {
     success = {
-        you_have_been_clocked_in = "Sie haben sich angemeldet",
+        you_have_been_clocked_in = "Du wurdest eingeloggt",
+        sold = 'Du hast %{amount} %{item} für $%{price} verkauft',
     },
     text = {
         point_enter_warehouse = "[E] Lager betreten",
-        enter_warehouse= "Lager betreten",
-        exit_warehouse= "Lager verlassen",
+        enter_warehouse = "Lager betreten",
+        exit_warehouse = "Lager verlassen",
         point_exit_warehouse = "[E] Lager verlassen",
-        clock_out = "[E] Abmelden",
-        clock_in = "[E] Anmelden",
+        toggle_duty = "Schicht wechseln",
+        point_toggle_duty = "[E] Schicht wechseln",
         hand_in_package = "Paket abgeben",
         point_hand_in_package = "[E] Paket abgeben",
-        get_package = "Paket holen",
-        point_get_package = "[E] Paket holen",
-        picking_up_the_package = "Paket wird aufgehoben",
+        get_package = "Paket abholen",
+        point_get_package = "[E] Paket abholen",
+        picking_up_the_package = "Paket wird abgeholt",
         unpacking_the_package = "Paket wird ausgepackt",
+        clock_in = "Du bist eingeloggt",
+        clock_out = "Du bist ausgeloggt",
+        sell_materials = "Materialien verkaufen",
+        point_sell_materials = "[E] Materialien verkaufen",
+        price = "Preis: $%{price}",
+        amount = "Menge",
+        sell = "Verkaufen",
     },
     error = {
-        you_have_clocked_out = "Sie haben sich abgemeldet"
+        you_have_clocked_out = "Du hast dich ausgeloggt",
+        nothing_to_sell = "Du hast nichts zu verkaufen",
+        out_of_stock = "%{item} ist ausverkauft",
+        too_far_to_sell = "Du bist zu weit entfernt, um zu verkaufen",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'de' then
-    Lang = Locale:new({
-        phrases = Translations,
-        warnOnMissing = true,
-        fallbackLang = Lang,
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -31,8 +31,10 @@ local Translations = {
         too_far_to_sell = "Du bist zu weit entfernt, um zu verkaufen",
     },
 }
-
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'de' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,23 +1,34 @@
 local Translations = {
     success = {
         you_have_been_clocked_in = "You Have Been Clocked In",
+        sold = 'You Have Sold %{amount} %{item} For $%{price}',
     },
     text = {
         point_enter_warehouse = "[E] Enter Warehouse",
         enter_warehouse= "Enter Warehouse",
         exit_warehouse= "Exit Warehouse",
         point_exit_warehouse = "[E] Exit Warehouse",
-        clock_out = "[E] Clock Out",
-        clock_in = "[E] Clock In",
+        toggle_duty = "Toggle Duty",
+        point_toggle_duty = "[E] Toggle Duty",
         hand_in_package = "Hand In Package",
         point_hand_in_package = "[E] Hand In Package",
         get_package = "Get Package",
         point_get_package = "[E] Get Package",
         picking_up_the_package = "Picking up the package",
         unpacking_the_package = "Unpacking the package",
+        clock_in = "You Have Clocked In",
+        clock_out = "You Have Clocked Out",
+        sell_materials = "Sell Materials",
+        point_sell_materials = "[E] Sell Materials",
+        price = "Price: $%{price}",
+        amount = "Amount",
+        sell = "Sell",
     },
     error = {
-        you_have_clocked_out = "You Have Clocked Out"
+        you_have_clocked_out = "You Have Clocked Out",
+        nothing_to_sell = "You Have Nothing To Sell",
+        out_of_stock = "%{item} Is Out Of Stock",
+        too_far_to_sell = "You Are Too Far Away To Sell",
     },
 }
 

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -1,29 +1,38 @@
 local Translations = {
     success = {
-        you_have_been_clocked_in = "Has registrado la entrada",
+        you_have_been_clocked_in = "Has iniciado sesión",
+        sold = 'Has vendido %{amount} %{item} por $%{price}',
     },
     text = {
         point_enter_warehouse = "[E] Entrar al almacén",
-        enter_warehouse= "Entrar al almacén",
-        exit_warehouse= "Salir del almacén",
+        enter_warehouse = "Entrar al almacén",
+        exit_warehouse = "Salir del almacén",
         point_exit_warehouse = "[E] Salir del almacén",
-        clock_out = "[E] Marcar la salida",
-        clock_in = "[E] Marcar la entrada",
-        hand_in_package = "Paquete de mano",
-        point_hand_in_package = "[E] Paquete de mano",
+        toggle_duty = "Cambiar turno",
+        point_toggle_duty = "[E] Cambiar turno",
+        hand_in_package = "Entregar paquete",
+        point_hand_in_package = "[E] Entregar paquete",
         get_package = "Obtener paquete",
         point_get_package = "[E] Obtener paquete",
         picking_up_the_package = "Recogiendo el paquete",
-        unpacking_the_package = "Desempacando",
+        unpacking_the_package = "Desempaquetando el paquete",
+        clock_in = "Has iniciado sesión",
+        clock_out = "Has cerrado sesión",
+        sell_materials = "Vender materiales",
+        point_sell_materials = "[E] Vender materiales",
+        price = "Precio: $%{price}",
+        amount = "Cantidad",
+        sell = "Vender",
     },
     error = {
-        you_have_clocked_out = "Has registrado la salida"
+        you_have_clocked_out = "Has cerrado sesión",
+        nothing_to_sell = "No tienes nada para vender",
+        out_of_stock = "%{item} está agotado",
+        too_far_to_sell = "Estás demasiado lejos para vender",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'es' then
-    Lang = Lang or Locale:new({
-        phrases = Translations,
-        warnOnMissing = true
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/es.lua
+++ b/locales/es.lua
@@ -32,7 +32,9 @@ local Translations = {
     },
 }
 
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'es' then
+    Lang = Lang or Locale:new({
+        phrases = Translations,
+        warnOnMissing = true
+    })
+end

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -33,7 +33,7 @@ local Translations = {
 }
 
 if GetConvar('qb_locale', 'en') == 'nl' then
-    Lang = Lang or Locale:new({
+    Lang = Locale:new({
         phrases = Translations,
         warnOnMissing = true,
         fallbackLang = Lang,

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -1,30 +1,38 @@
 local Translations = {
     success = {
-        you_have_been_clocked_in = "Je bent indienst gegaan",
+        you_have_been_clocked_in = "Je bent ingelogd",
+        sold = 'Je hebt %{amount} %{item} verkocht voor $%{price}',
     },
     text = {
-        point_enter_warehouse = "[E] Enter stockage",
-        enter_warehouse= "Enter Stockage",
-        exit_warehouse= "Verlaat Stockage",
-        point_exit_warehouse = "[E] Exit Stockage",
-        clock_out = "[E] Ga uitdienst",
-        clock_in = "[E] Ga indienst",
-        hand_in_package = "Lever pakketje in",
-        point_hand_in_package = "[E] Lever pakketje in",
-        get_package = "Neem pakketje",
-        point_get_package = "[E] Neem pakketje",
-        picking_up_the_package = "Neem het pakketje",
-        unpacking_the_package = "Pakketje openen",
+        point_enter_warehouse = "[E] Betreed magazijn",
+        enter_warehouse = "Betreed magazijn",
+        exit_warehouse = "Verlaat magazijn",
+        point_exit_warehouse = "[E] Verlaat magazijn",
+        toggle_duty = "Schakel dienst in/uit",
+        point_toggle_duty = "[E] Schakel dienst in/uit",
+        hand_in_package = "Lever pakket in",
+        point_hand_in_package = "[E] Lever pakket in",
+        get_package = "Haal pakket op",
+        point_get_package = "[E] Haal pakket op",
+        picking_up_the_package = "Pakket ophalen",
+        unpacking_the_package = "Pakket uitpakken",
+        clock_in = "Je bent ingelogd",
+        clock_out = "Je bent uitgelogd",
+        sell_materials = "Verkoop materialen",
+        point_sell_materials = "[E] Verkoop materialen",
+        price = "Prijs: $%{price}",
+        amount = "Hoeveelheid",
+        sell = "Verkopen",
     },
     error = {
-        you_have_clocked_out = "Je bent uitdienst gegaan"
+        you_have_clocked_out = "Je bent uitgelogd",
+        nothing_to_sell = "Je hebt niets om te verkopen",
+        out_of_stock = "%{item} is niet op voorraad",
+        too_far_to_sell = "Je bent te ver weg om te verkopen",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'nl' then
-    Lang = Lang or Locale:new({
-        phrases = Translations,
-        warnOnMissing = true,
-        fallbackLang = Lang,
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/locales/nl.lua
+++ b/locales/nl.lua
@@ -32,7 +32,10 @@ local Translations = {
     },
 }
 
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'nl' then
+    Lang = Lang or Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/pt-br.lua
+++ b/locales/pt-br.lua
@@ -32,7 +32,10 @@ local Translations = {
     },
 }
 
-Lang = Lang or Locale:new({
-    phrases = Translations,
-    warnOnMissing = true
-})
+if GetConvar('qb_locale', 'en') == 'pt-br' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end

--- a/locales/pt-br.lua
+++ b/locales/pt-br.lua
@@ -1,30 +1,38 @@
 local Translations = {
     success = {
-        you_have_been_clocked_in = "Você foi registrado na entrada",
+        you_have_been_clocked_in = "Você foi registrado",
+        sold = 'Você vendeu %{amount} %{item} por $%{price}',
     },
     text = {
-        point_enter_warehouse = "[E] Entrar no Armazém",
-        enter_warehouse = "Entrar no Armazém",
-        exit_warehouse = "Sair do Armazém",
-        point_exit_warehouse = "[E] Sair do Armazém",
-        clock_out = "[E] Registrar Saída",
-        clock_in = "[E] Registrar Entrada",
-        hand_in_package = "Entregar Pacote",
-        point_hand_in_package = "[E] Entregar Pacote",
-        get_package = "Pegar Pacote",
-        point_get_package = "[E] Pegar Pacote",
+        point_enter_warehouse = "[E] Entrar no armazém",
+        enter_warehouse = "Entrar no armazém",
+        exit_warehouse = "Sair do armazém",
+        point_exit_warehouse = "[E] Sair do armazém",
+        toggle_duty = "Alternar turno",
+        point_toggle_duty = "[E] Alternar turno",
+        hand_in_package = "Entregar pacote",
+        point_hand_in_package = "[E] Entregar pacote",
+        get_package = "Pegar pacote",
+        point_get_package = "[E] Pegar pacote",
         picking_up_the_package = "Pegando o pacote",
         unpacking_the_package = "Desembalando o pacote",
+        clock_in = "Você foi registrado",
+        clock_out = "Você foi deslogado",
+        sell_materials = "Vender materiais",
+        point_sell_materials = "[E] Vender materiais",
+        price = "Preço: $%{price}",
+        amount = "Quantidade",
+        sell = "Vender",
     },
     error = {
-        you_have_clocked_out = "Você registrou sua saída",
+        you_have_clocked_out = "Você foi deslogado",
+        nothing_to_sell = "Você não tem nada para vender",
+        out_of_stock = "%{item} está fora de estoque",
+        too_far_to_sell = "Você está muito longe para vender",
     },
 }
 
-if GetConvar('qb_locale', 'en') == 'pt-br' then
-    Lang = Locale:new({
-        phrases = Translations,
-        warnOnMissing = true,
-        fallbackLang = Lang,
-    })
-end
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,7 +12,7 @@ local Recieve = {
 }
 local luckyItem = 'cryptostick' -- Item to be given as a lucky item
 local maxRecieved = 5 -- Max items to be received
-local dropLocation = vector4(1048.224, -3097.071, -38.999, 274.810)
+local dropLocation = Config.dropLocation
 local LuckyItemChance = 20 -- 20% chance to get a lucky item
 local uhohs = {}
 local Sales, Stock, salesLoc = {}, {}, Config.SellPed

--- a/server/main.lua
+++ b/server/main.lua
@@ -16,6 +16,8 @@ local dropLocation = vector4(1048.224, -3097.071, -38.999, 274.810)
 local LuckyItemChance = 20 -- 20% chance to get a lucky item
 local uhohs = {}
 local Sales, Stock, salesLoc = {}, {}, Config.SellPed
+
+
 if Config.SellMaterials then 
     Sales = { -- key is item, value is price
         metalscrap = 2,
@@ -104,7 +106,7 @@ local function checkStock(source, item, amount)
     if Stock[item] >= amount then
         return true
     else
-        TriggerClientEvent('QBCore:Notify', source, QBCore.Shared.Items[item].label .. ' Is Out Of Stock!', 'error')
+        TriggerClientEvent('QBCore:Notify', source, Lang:t('error.out_of_stock', {item = item}), 'error')
         return false
     end
 end
@@ -115,13 +117,14 @@ local function sellMaterials(src, item, amount)
     local has = Player.Functions.GetItemByName(item)
     if has and has.amount < amount then
         amount = has.amount
+        price = Sales[item] * amount
     end
     if Player.Functions.RemoveItem(item, amount) then
         Player.Functions.AddMoney('cash', price)
-        TriggerClientEvent('QBCore:Notify', src, 'You sold ' .. amount .. ' ' .. QBCore.Shared.Items[item].label .. ' for $' .. price, 'success')
+        TriggerClientEvent('QBCore:Notify', src, Lang:t('success.sold', {amount = amount, item = QBCore.Shared.Items[item].label, price = price}), 'success')
         adjustStock(item, 'add', amount)
     else
-        TriggerClientEvent('QBCore:Notify', src, 'You do not have enough ' .. QBCore.Shared.Items[item].label .. ' to sell', 'error')
+        TriggerClientEvent('QBCore:Notify', src, Lang:t('error.nothing_to_sell'), 'error')
         return
     end
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,7 +12,7 @@ local Recieve = {
 }
 local luckyItem = 'cryptostick' -- Item to be given as a lucky item
 local maxRecieved = 5 -- Max items to be received
-local dropLocation = Config.dropLocation
+local dropLocation = Config.DropLocation
 local LuckyItemChance = 20 -- 20% chance to get a lucky item
 local uhohs = {}
 local Sales, Stock, salesLoc = {}, {}, Config.SellPed

--- a/server/main.lua
+++ b/server/main.lua
@@ -49,7 +49,7 @@ RegisterNetEvent('qb-recyclejob:server:getItem', function()
     local Player = QBCore.Functions.GetPlayer(src)
     if not isClose(src) then
         uhohs[src] = uhohs[src] + 1 or 0
-        if uhohs[src] > 3 then 
+        if uhohs[src] >= 3 then
             exploitBan(src, 'Exploiting distance on qb-recyclejob')
         end
         return

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,29 +1,72 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
--- Events
+local Recieve = {
+    {item = 'metalscrap', min = 1, max = 5},
+    {item = 'plastic', min = 1, max = 5},
+    {item = 'copper', min = 1, max = 5},
+    {item = 'rubber', min = 1, max = 5},
+    {item = 'iron', min = 1, max = 5},
+    {item = 'aluminum', min = 1, max = 5},
+    {item = 'steel', min = 1, max = 5},
+    {item = 'glass', min = 1, max = 5},
+}
+local luckyItem = 'cryptostick' -- Item to be given as a lucky item
+local maxRecieved = 5 -- Max items to be received
+local dropLocation = vector4(1048.224, -3097.071, -38.999, 274.810)
+local LuckyItemChance = 20 -- 20% chance to get a lucky item
+local uhohs = {}
+
+local function exploitBan(id, reason)
+    MySQL.insert('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        {
+            GetPlayerName(id),
+            QBCore.Functions.GetIdentifier(id, 'license'),
+            QBCore.Functions.GetIdentifier(id, 'discord'),
+            QBCore.Functions.GetIdentifier(id, 'ip'),
+            reason,
+            2147483647,
+            'qb-recyclejob'
+        })
+    TriggerEvent('qb-log:server:CreateLog', 'recyclejob', 'Player Banned', 'red',
+        string.format('%s was banned by %s for %s', GetPlayerName(id), 'qb-recyclejob', reason), true)
+    DropPlayer(id, 'You were permanently banned by the server for: Exploiting')
+end
+
+local function isClose(source)
+    local playerPed = GetPlayerPed(source)
+    local playerCoords = GetEntityCoords(playerPed)
+    local distance = #(playerCoords - vector3(dropLocation.x, dropLocation.y, dropLocation.z))
+
+    if distance < 5.0 then
+        return true
+    else
+        return false
+    end
+end
 
 RegisterNetEvent('qb-recyclejob:server:getItem', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    for _ = 1, math.random(1, Config.MaxItemsReceived), 1 do
-        local randItem = Config.ItemTable[math.random(1, #Config.ItemTable)]
-        local amount = math.random(Config.MinItemReceivedQty, Config.MaxItemReceivedQty)
-        exports['qb-inventory']:AddItem(src, randItem, amount, false, false, 'qb-recyclejob:server:getItem')
-        TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[randItem], 'add')
-        Wait(500)
+    if not isClose(src) then
+        uhohs[src] = uhohs[src] + 1 or 0
+        if uhohs[src] > 3 then 
+            exploitBan(src, 'Exploiting distance on qb-recyclejob')
+        end
+        return
     end
+    local itemAmountRecieved = math.random(1, maxRecieved)
+    repeat
+        Wait(1)
+        local item = Recieve[math.random(1, #Recieve)]
+        local itemAmount = math.random(item.min, item.max)
+        itemAmountRecieved = itemAmountRecieved - 1
+        Player.Functions.AddItem(item.item, itemAmount)
+        TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[item.item], 'add', itemAmount)
+    until itemAmountRecieved == 0
 
-    local chance = math.random(1, 100)
-    if chance < 7 then
-        exports['qb-inventory']:AddItem(src, Config.ChanceItem, 1, false, false, 'qb-recyclejob:server:getItem')
-        TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[Config.ChanceItem], 'add')
-    end
-
-    local luck = math.random(1, 10)
-    local odd = math.random(1, 10)
-    if luck == odd then
-        local random = math.random(1, 3)
-        exports['qb-inventory']:AddItem(src, Config.LuckyItem, random, false, false, 'qb-recyclejob:server:getItem')
-        TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[Config.LuckyItem], 'add')
+    local luckyChance = math.random(1, 100)
+    if luckyChance <= LuckyItemChance then 
+        Player.Functions.AddItem(luckyItem, 1)
+        TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[luckyItem], 'add', 1)
     end
 end)


### PR DESCRIPTION
things added server side

- security checks in server
  - moved loot pool to the server
  - added exploitBan function if caught more than 3 times not being close enough to trigger an event properly
  
- things added client side
  - changed the blip that appears above a box that needs to be ran in a Wait(0) to an object outline
  -  tabled the props that spawn for easier storage and grabbing data
  

- added features
  - Config.SellMaterials 
     - ped spawned inside of the recycle center that you can sell unwanted materials to. each are set to $2
     - shows a menu of what materials you have and can sell based on what is in your inventory
        - if you dont have metalscrap, you wont see metalscrap in the menu
     - Config.LimitedMaterials
       - if you have this to true, there are a certain amount you can get of a certain material before the server is restarted
       - if you have Config.SellMaterials as true when you sell to the ped, it will get added back into the limited material amount 
          - i.e starts with 3000 glass, you take 100, now there is only 2900, you can sell 50 of it to the ped, now there is 2950 left.


- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]

- tested by me, BobAtari, Illusion, TropicGalaxy, and DJ Raymond