### PR TITLE
fix(client): outline color and duty reset

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -31,8 +31,10 @@ end)
 
 local function DrawPackageLocationBlip()
     if not Config.DrawPackageLocationBlip then return end
-    SetEntityDrawOutline(props[packageCoords], true)
-    SetEntityDrawOutlineColor(props[packageCoords], 15, 20, 60)
+    local ent = props[packageCoords]
+    SetEntityDrawOutline(ent, true)
+    SetEntityDrawOutlineColor(15, 20, 60, 1.0)
+    SetEntityDrawOutlineShader(0)
 end
 
 local function GetRandomPackage()
@@ -95,6 +97,10 @@ local function ExitLocation()
     DoScreenFadeIn(500)
 
     onDuty = false
+    if packageCoords then
+        SetEntityDrawOutline(props[packageCoords], false)
+        packageCoords = nil
+    end
 
     if carryPackage then
         DropPackage()

--- a/locales/ja.lua
+++ b/locales/ja.lua
@@ -1,0 +1,38 @@
+local Translations = {
+    success = {
+        you_have_been_clocked_in = '出勤しました',
+        sold = '%{amount}個の%{item}を$%{price}で売却しました',
+    },
+    text = {
+        point_enter_warehouse = '[E] 倉庫に入る',
+        enter_warehouse = '倉庫に入る',
+        exit_warehouse = '倉庫から出る',
+        point_exit_warehouse = '[E] 倉庫から出る',
+        toggle_duty = '出勤/退勤',
+        point_toggle_duty = '[E] 出勤/退勤',
+        hand_in_package = 'パッケージを渡す',
+        point_hand_in_package = '[E] パッケージを渡す',
+        get_package = 'パッケージを入手',
+        point_get_package = '[E] パッケージを入手',
+        picking_up_the_package = 'パッケージを取る',
+        unpacking_the_package = 'パッケージを開封する',
+        clock_in = '出勤しました',
+        clock_out = '退勤しました',
+        sell_materials = '素材を売却',
+        point_sell_materials = '[E] 素材を売却',
+        price = '価格: $%{price}',
+        amount = '数量',
+        sell = '売却',
+    },
+    error = {
+        you_have_clocked_out = '退勤しました',
+        nothing_to_sell = '売却できるものがありません',
+        out_of_stock = '%{item} は在庫切れです',
+        too_far_to_sell = '売却場所から離れすぎています',
+    },
+}
+
+Lang = Lang or Locale:new({
+    phrases = Translations,
+    warnOnMissing = true
+})


### PR DESCRIPTION
1. Package outline color not applied on the target crate while on duty.
2. Duty state not fully reset when leaving via the warehouse exit door. 
After leaving while on duty, the player appeared clocked out, but re-entering the warehouse left the previous package outline active and the crate could still be picked up.
Toggling duty again could add a second outlined crate.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
